### PR TITLE
fixed typo

### DIFF
--- a/src/schema/meeting/query.ts
+++ b/src/schema/meeting/query.ts
@@ -12,7 +12,7 @@ export const MeetingsQuery = queryField('meetings', {
     },
 });
 
-export const MeetingByIdQuery = queryField('meetingsById', {
+export const MeetingByIdQuery = queryField('meetingById', {
     type: Meeting,
     description: 'Find a meeting by id from meetings youre participating in',
     args: {


### PR DESCRIPTION
Frontenden prøver å kalle på meetingById, men det vil jo ikke funke når denne heter meetingsById